### PR TITLE
Force device registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ promhttp_metric_handler_errors_total{cause="gathering"} 0
 
 The deploy procedure should:
 - configure 2 FPP instances for every branding: one for production and one for sandbox;
-  the sandbox environment is mandatory to test iOS applications installed from [TestFlight](https://developer.apple.com/testflight/)
+  the sandbox environment is mandatory to test iOS applications running inside [Xcode](https://developer.apple.com/xcode/)
 - configure a Traefik instance to authenticate the requests and forward them to the right FPP instance:
   - `ping` and `send` endpoints must be authenticated by Traefik using `my.nethesis.it`
   - `register` and `deregister` endpoints should not be authenticated by Traefik

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The server exposes the following APIs:
 
 - `/register`: POST, register a device. Both the device token and the topic must be a string of 64 hex characters.
   If device token and topic are valid, the server will save the token associated to the given topic.
-  Token/topic association will expire after 356 days: applications must be opened at least once every 6 months
+  Token/topic association will expire after 90 days: applications must be opened at least once every 3 months
   to keep receiving notifications.
   This endpoint must be validated with an header `Instance-Token`, see `INSTANCE_TOKEN` env var.
   Parameters:

--- a/audit.go
+++ b/audit.go
@@ -34,7 +34,9 @@ func audit(record []string) {
 			}
 		}
 	} else if record[0] == "register" || record[0] == "deregister" {
-		metrics.RegisteredDevices.Set(countRegisteredDevices())
+		apnCount, fbCount := countRegisteredDevices()
+		metrics.RegisteredAPNDevices.Set(apnCount)
+		metrics.RegisteredFirebaseDevices.Set(fbCount)
 	}
 }
 

--- a/audit.go
+++ b/audit.go
@@ -17,27 +17,7 @@ func audit(record []string) {
 	}
 	w.Flush()
 
-	// Update metrics
-	if record[0] == "send" {
-		metrics.TotalSendCount.Inc()
-		if record[1] == "apple" {
-			if record[2] == "success" {
-				metrics.APNSuccessCount.Inc()
-			} else {
-				metrics.APNErrorCount.Inc()
-			}
-		} else if record[1] == "firebase" {
-			if record[2] == "success" {
-				metrics.FirebaseSuccessCount.Inc()
-			} else {
-				metrics.FirebaseErrorCount.Inc()
-			}
-		}
-	} else if record[0] == "register" || record[0] == "deregister" {
-		apnCount, fbCount := countRegisteredDevices()
-		metrics.RegisteredAPNDevices.Set(apnCount)
-		metrics.RegisteredFirebaseDevices.Set(fbCount)
-	}
+	updateMetrics(record)
 }
 
 func auditSend(result string, response string, notification *Notification) {

--- a/db.go
+++ b/db.go
@@ -56,9 +56,9 @@ func getTokenFromTopic(topic string) (string, error) {
 }
 
 func saveTopicToken(topic string, token string, ttype string) error {
-	// Set a 6-months  TTL
+	// Firebase doc suggests 2 months TTL, let's be conservative and set it to 3 months
 	return db.Update(func(txn *badger.Txn) error {
-		record := badger.NewEntry([]byte(topic), []byte(token)).WithTTL(24 * 180 * time.Hour)
+		record := badger.NewEntry([]byte(topic), []byte(token)).WithTTL(24 * 90 * time.Hour)
 		if ttype == "apple" {
 			record.WithMeta(Apple)
 		} else {

--- a/main.go
+++ b/main.go
@@ -269,9 +269,7 @@ func main() {
 	metrics, reg = initMetrics()
 	promHandler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg})
 	// Update db metrics
-	apnCount, fbCount := countRegisteredDevices()
-	metrics.RegisteredAPNDevices.Set(apnCount)
-	metrics.RegisteredFirebaseDevices.Set(fbCount)
+	updateDeviceMetrics()
 
 	router := gin.Default()
 	router.GET("/ping", ping)

--- a/main.go
+++ b/main.go
@@ -228,6 +228,10 @@ func send(c *gin.Context) {
 			return
 		}
 
+		// Extend topic expiration
+		// Ignore error here. Worst case: the topic expires after the TTL
+		saveTopicToken(notification.Topic, deviceToken, notification.Type)
+
 		auditSend("success", response, &notification)
 		c.JSON(http.StatusOK, Response{Message: response})
 		return

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strings"
 	"syscall"
 	"time"
 	"unicode"
@@ -223,6 +224,11 @@ func send(c *gin.Context) {
 		}
 		response, err := fbClient.Send(ctx, message)
 		if err != nil {
+			// Clean stale token
+			// 404 response: https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
+			if strings.Contains(err.Error(), "registration-token-not-registered") {
+				deleteTopic(notification.Topic)
+			}
 			c.JSON(http.StatusInternalServerError, Response{Message: err.Error()})
 			auditSend("error", err.Error(), &notification)
 			return

--- a/main.go
+++ b/main.go
@@ -108,7 +108,6 @@ func register(c *gin.Context) {
 	}
 
 	// If the token is valid store <topic>:<device> key/value
-	// Set a TTL of 6 months, the TTL is updated on each use
 	dberr := saveTopicToken(registration.Topic, registration.Token, registration.Type)
 
 	if dberr != nil {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -219,7 +220,9 @@ func send(c *gin.Context) {
 			Android: &messaging.AndroidConfig{
 				Priority: "high",
 			},
-			Data:  map[string]string{"call-id": notification.CallId, "uuid": notification.Uuid},
+			// Android notification does not require any info: it is used only to wake up the app
+			// Just send a timestamp to make sure notification is always different
+			Data:  map[string]string{"timestamp": strconv.FormatInt(time.Now().UnixMilli(), 10)},
 			Token: deviceToken,
 		}
 		response, err := fbClient.Send(ctx, message)

--- a/main.go
+++ b/main.go
@@ -196,6 +196,11 @@ func send(c *gin.Context) {
 		}
 
 		if res.StatusCode != 200 {
+			// Cleanup stale token
+			// 410 response: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW15
+			if res.StatusCode == 410 {
+				deleteTopic(notification.Topic)
+			}
 			c.JSON(http.StatusInternalServerError, Response{Message: res.Reason})
 			auditSend("error", res.Reason, &notification)
 			return

--- a/metrics.go
+++ b/metrics.go
@@ -17,6 +17,34 @@ type Metrics struct {
 	FirebaseErrorCount   prometheus.Counter
 }
 
+func updateDeviceMetrics() {
+	apnCount, fbCount := countRegisteredDevices()
+	metrics.RegisteredAPNDevices.Set(apnCount)
+	metrics.RegisteredFirebaseDevices.Set(fbCount)
+}
+
+func updateMetrics(record []string) {
+	if record[0] == "send" {
+		metrics.TotalSendCount.Inc()
+		if record[1] == "apple" {
+			if record[2] == "success" {
+				metrics.APNSuccessCount.Inc()
+			} else {
+				metrics.APNErrorCount.Inc()
+			}
+		} else if record[1] == "firebase" {
+			if record[2] == "success" {
+				metrics.FirebaseSuccessCount.Inc()
+			} else {
+				metrics.FirebaseErrorCount.Inc()
+			}
+		}
+	} else if record[0] == "register" || record[0] == "deregister" {
+		updateDeviceMetrics()
+	}
+
+}
+
 func initMetrics() (*Metrics, *prometheus.Registry) {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))

--- a/metrics.go
+++ b/metrics.go
@@ -8,7 +8,8 @@ import (
 /** Metrics functions and structs **/
 
 type Metrics struct {
-	RegisteredDevices    prometheus.Gauge
+	RegisteredAPNDevices    prometheus.Gauge
+	RegisteredFirebaseDevices    prometheus.Gauge
 	TotalSendCount       prometheus.Counter
 	APNSuccessCount      prometheus.Counter
 	APNErrorCount        prometheus.Counter
@@ -20,9 +21,13 @@ func initMetrics() (*Metrics, *prometheus.Registry) {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	m := &Metrics{
-		RegisteredDevices: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "fpp_registered_devices",
-			Help: "Number of registered devices.",
+		RegisteredAPNDevices: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "fpp_registered_apn_devices",
+			Help: "Number of registered Apple APN devices.",
+		}),
+		RegisteredFirebaseDevices: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "fpp_registered_firebase_devices",
+			Help: "Number of registered Google Firebase devices.",
 		}),
 		TotalSendCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "fpp_total_send_count",
@@ -45,7 +50,8 @@ func initMetrics() (*Metrics, *prometheus.Registry) {
 			Help: "Number of errored Google Firebase notifications.",
 		}),
 	}
-	reg.MustRegister(m.RegisteredDevices)
+	reg.MustRegister(m.RegisteredAPNDevices)
+	reg.MustRegister(m.RegisteredFirebaseDevices)
 	reg.MustRegister(m.TotalSendCount)
 	reg.MustRegister(m.APNSuccessCount)
 	reg.MustRegister(m.APNErrorCount)

--- a/metrics.go
+++ b/metrics.go
@@ -8,13 +8,13 @@ import (
 /** Metrics functions and structs **/
 
 type Metrics struct {
-	RegisteredAPNDevices    prometheus.Gauge
-	RegisteredFirebaseDevices    prometheus.Gauge
-	TotalSendCount       prometheus.Counter
-	APNSuccessCount      prometheus.Counter
-	APNErrorCount        prometheus.Counter
-	FirebaseSuccessCount prometheus.Counter
-	FirebaseErrorCount   prometheus.Counter
+	RegisteredAPNDevices      prometheus.Gauge
+	RegisteredFirebaseDevices prometheus.Gauge
+	TotalSendCount            prometheus.Counter
+	APNSuccessCount           prometheus.Counter
+	APNErrorCount             prometheus.Counter
+	FirebaseSuccessCount      prometheus.Counter
+	FirebaseErrorCount        prometheus.Counter
 }
 
 func updateDeviceMetrics() {

--- a/models.go
+++ b/models.go
@@ -1,5 +1,10 @@
 package main
 
+/** Constants **/
+
+const Apple byte = 1
+const Firebase byte = 2
+
 /** Structs definition **/
 
 type Response struct {
@@ -18,4 +23,5 @@ type Notification struct {
 type Registration struct {
 	Token string `json:"token"`
 	Topic string `json:"topic"`
+	Type  string `json:"type"`
 }


### PR DESCRIPTION
It seems Firebase takes a while before sending a message to a topic.
From [official doc](https://firebase.google.com/docs/cloud-messaging/android/topic-messaging):

> Topic messages are optimized for throughput rather than latency. For fast, secure delivery to single devices or small groups of devices,[ target messages to registration tokens](https://firebase.google.com/docs/cloud-messaging/send-message#send_messages_to_specific_devices), not topics.